### PR TITLE
Deploy GitHub Pages directly from Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+on:
+  push:
+    branches:
+    - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup Python
+      uses: actions/setup-python@v4.7.1
+      with:
+        python-version: 3.11
+    - name: install dependencies
+      run: pip3 install numpy loguru rich flask sphinx-rtd-theme
+    - run: python3 setup.py install
+    - name: Build website
+      run: |
+        python3 setup.py bdist_wheel
+        cp ./dist/*.whl ./website/static
+    - uses: actions/upload-pages-artifact@v1
+      with:
+        path: "./website/static"
+        
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/deploy-pages@v1
+        id: deployment

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: 3.11
     - name: install dependencies
-      run: pip3 install numpy loguru rich flask sphinx-rtd-theme
+      run: pip3 install numpy loguru rich flask sphinx-rtd-theme wheel
     - run: python3 setup.py install
     - name: Build website
       run: |

--- a/genius_invocation/card/character/characters/Azhdaha.py
+++ b/genius_invocation/card/character/characters/Azhdaha.py
@@ -25,7 +25,7 @@ class AuraofMajesty(ElementalSkill):
     name_ch = "磅礴之气"
     type: SkillType = SkillType.ELEMENTAL_SKILL
     damage_type: SkillType = SkillType.ELEMENTAL_SKILL
-    main_damage_element: ElementType = ElementType.Geo
+    main_damage_element: ElementType = ElementType.GEO
     main_damage: int = 3
     piercing_damage: int = 0
     cost = [{'cost_num':3, 'cost_type':CostType.GEO}]

--- a/genius_invocation/web/main.py
+++ b/genius_invocation/web/main.py
@@ -2,6 +2,7 @@
 from genius_invocation.web.game.game import GeniusGame
 from genius_invocation.web.game.action import *
 from genius_invocation.utils import *
+from genius_invocation.main import select_card
 import genius_invocation.card.action as actioncard
 from genius_invocation.user_layout import layout
 from genius_invocation.web.utils_dict import get_dict


### PR DESCRIPTION
Your project has a dedicated Web UI but currently need to deploy by users themselves. Repo flick-ai/Genius-Invokation-Website is now updated manually and, if this PR is merged, it will automatically deploy the site for you.

After accepting this PR, just enable Settings -> Pages -> Source -> GitHub Actions, https://flick-ai.github.io/Genius-Invokation *should* be built automatically when there are pulls on the `main` branch.

This PR also fixes some bugs that block the app to load.